### PR TITLE
Ensure db container port is connectable before proceeding with migrations

### DIFF
--- a/src/main/java/org/testcontainers/jooq/codegen/datasource/ContainerTargetDatasource.java
+++ b/src/main/java/org/testcontainers/jooq/codegen/datasource/ContainerTargetDatasource.java
@@ -4,6 +4,7 @@ import java.sql.Driver;
 import java.util.Objects;
 import lombok.experimental.Delegate;
 import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
 
 /**
  * Containerized target datasource
@@ -18,6 +19,7 @@ public final class ContainerTargetDatasource implements TargetDatasource {
 
     public ContainerTargetDatasource(JdbcDatabaseContainer<?> container) {
         this.container = Objects.requireNonNull(container);
+        this.container.setWaitStrategy(new HostPortWaitStrategy());
         this.container.start();
     }
 


### PR DESCRIPTION
This prevents migrations to fail because db port is not yet ready to accept connections which is manifested with this error:

```
[INFO] Ryuk started - will monitor and terminate Testcontainers containers on JVM exit
[INFO] Checking the system...
[INFO] ✔︎ Docker server version should be at least 1.6.0
[INFO] Creating container for image: postgres:15-alpine
[INFO] Container postgres:15-alpine is starting: 4894531244e7d4688a7a7fd7b19c705eb52b92fe67b87466a52e19888b436f29
[INFO] Container postgres:15-alpine started in PT2.118826S
[INFO] Container is started (JDBC URL: jdbc:postgresql://localhost:49329/test?loggerLevel=OFF)
Aug 03, 2023 3:13:38 PM org.flywaydb.core.internal.license.VersionPrinter printVersionOnly
INFO: Flyway Community Edition 9.16.3 by Redgate
Aug 03, 2023 3:13:38 PM org.flywaydb.core.internal.license.VersionPrinter printVersion
INFO: See release notes here: https://rd.gt/416ObMi
Aug 03, 2023 3:13:38 PM org.flywaydb.core.internal.license.VersionPrinter printVersion
INFO:
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.717 s
[INFO] Finished at: 2023-08-03T15:13:39+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.testcontainers:testcontainers-jooq-codegen-maven-plugin:0.0.3-SNAPSHOT:generate (generate-jooq-sources) on project postgres-flyway-example: Error running jOOQ code generation tool: Unable to obtain connection from database (jdbc:postgresql://localhost:49329/test?loggerLevel=OFF) for user 'test': Connection to localhost:49329 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.
``` 